### PR TITLE
feat: allow numbers in board code jira reference

### DIFF
--- a/__tests__/lint.test.js
+++ b/__tests__/lint.test.js
@@ -1,48 +1,48 @@
 // noinspection JSUnresolvedFunction,JSUnresolvedVariable
 
-const lint = require('../src/lint.js');
+const lint = require("../src/lint.js");
 
-test('failure', () => {
-    const title = 'chore: use internal PR linting action';
-    const body = `Use the internal GitHub Action for linting PR title/body.
+test("failure", () => {
+  const title = "chore: use internal PR linting action";
+  const body = `Use the internal GitHub Action for linting PR title/body.
 
 We're using an internal one so that we can ensure a few things specific
 to Finder's use case, including the correct placement of the Jira
 reference.`;
 
-    const errorCallback = jest.fn(() => {});
-    lint(body, title, errorCallback, () => {});
-    expect(errorCallback.mock.calls.length).toBe(1);
+  const errorCallback = jest.fn(() => {});
+  lint(body, title, errorCallback, () => {});
+  expect(errorCallback.mock.calls.length).toBe(1);
 });
 
-test('failure with empty line', () => {
-    const title = 'chore: something';
-    const body = `Some description
+test("failure with empty line", () => {
+  const title = "chore: something";
+  const body = `Some description
 
 Closes [ABC-123](https://finder.atlassian.net/browse/ABC-123)
 `;
 
-    const errorCallback = jest.fn(() => {});
-    lint(body, title, errorCallback, () => {});
-    expect(errorCallback.mock.calls.length).toBe(1);
+  const errorCallback = jest.fn(() => {});
+  lint(body, title, errorCallback, () => {});
+  expect(errorCallback.mock.calls.length).toBe(1);
 });
 
-test('success', () => {
-    const title = 'chore: reinstate PR linter';
-    const body = `Upgrading to v1.0.6 which should fix the issue where PR descriptions
+test("success", () => {
+  const title = "chore: reinstate PR linter";
+  const body = `Upgrading to v1.0.6 which should fix the issue where PR descriptions
 like this one were failing the check:
 https://github.com/finderau/site/pull/5057
 
 Relates to [SRE-225]`;
 
-    const errorCallback = jest.fn(() => {});
-    lint(body, title, errorCallback, () => {});
-    expect(errorCallback.mock.calls.length).toBe(0);
+  const errorCallback = jest.fn(() => {});
+  lint(body, title, errorCallback, () => {});
+  expect(errorCallback.mock.calls.length).toBe(0);
 });
 
-test('success with checkboxes', () => {
-    const title = 'feat: improve redirect page performance';
-    const body = `#### Ticket Number
+test("success with checkboxes", () => {
+  const title = "feat: improve redirect page performance";
+  const body = `#### Ticket Number
 https://finder.atlassian.net/browse/CST-2332
 
 #### Description
@@ -64,31 +64,42 @@ Remember to follow the [Major Deployment Guidelines](https://github.com/finderau
 
 Relates to [CST-2332]`;
 
-    const errorCallback = jest.fn(() => {});
-    lint(body, title, errorCallback, () => {});
-    expect(errorCallback.mock.calls.length).toBe(0);
+  const errorCallback = jest.fn(() => {});
+  lint(body, title, errorCallback, () => {});
+  expect(errorCallback.mock.calls.length).toBe(0);
 });
 
-test('failure with full jira link', () => {
-    const title = 'chore: something';
-    const body = `Some description
+test("failure with full jira link", () => {
+  const title = "chore: something";
+  const body = `Some description
 
 Relates to https://finder.atlassian.net/browse/PLATFORM-4864
 `;
 
-const errorCallback = jest.fn(() => {});
-    lint(body, title, errorCallback, () => {});
-    expect(errorCallback.mock.calls.length).toBe(1);
+  const errorCallback = jest.fn(() => {});
+  lint(body, title, errorCallback, () => {});
+  expect(errorCallback.mock.calls.length).toBe(1);
 });
 
-test('failure with invalid jira reference', () => {
-    const title = 'chore: something';
-    const body = `Some description
+test("failure with invalid jira reference", () => {
+  const title = "chore: something";
+  const body = `Some description
 
 Relates to 1234
 `;
 
-const errorCallback = jest.fn(() => {});
-    lint(body, title, errorCallback, () => {});
-    expect(errorCallback.mock.calls.length).toBe(1);
+  const errorCallback = jest.fn(() => {});
+  lint(body, title, errorCallback, () => {});
+  expect(errorCallback.mock.calls.length).toBe(1);
+});
+
+test("success with jira reference containing numbers in board code", () => {
+  const title = "chore: something";
+  const body = `Some description
+
+Relates to [F1TRIAGE-1234]`;
+
+  const errorCallback = jest.fn(() => {});
+  lint(body, title, errorCallback, () => {});
+  expect(errorCallback.mock.calls.length).toBe(0);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-pr-linter",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Finder's GitHub commit linter, runs as a GitHub Action",
   "main": "index.js",
   "scripts": {

--- a/src/lint.js
+++ b/src/lint.js
@@ -27,7 +27,7 @@ module.exports = function (body, title, failureCallback, infoCallback) {
     } else {
         // Ensure that a valid Jira reference exists in the pull request body
         infoCallback('Checking PR body Jira reference');
-        const jiraReferenceRegex = new RegExp(/^(Relates to|Closes) \[([A-Za-z]+-[0-9]+)]$/gm);
+        const jiraReferenceRegex = new RegExp(/^(Relates to|Closes) \[([A-Za-z0-9]+-[0-9]+)]$/gm);
         let regexMatchFound = false;
         for (const line of bodyLines) {
             if (jiraReferenceRegex.test(line)) {


### PR DESCRIPTION
Currently, github-pr-linter doesn’t support F1TRIAGE  jira references and this PR should fix it.
